### PR TITLE
Fix absoluteNestingLevel property name.

### DIFF
--- a/Chadicus/ruleset.xml
+++ b/Chadicus/ruleset.xml
@@ -17,7 +17,7 @@
     <rule ref="Generic.Metrics.NestingLevel">
         <properties>
             <property name="nestingLevel" value="2" />
-            <property name="absolutenestingLevel" value="3" />
+            <property name="absoluteNestingLevel" value="3" />
         </properties>
     </rule>
     <rule ref="Squiz.PHP.DiscouragedFunctions" />


### PR DESCRIPTION
A change was introduced in PHPCS 3.8.0 that made this start failing.